### PR TITLE
feat: enhance chatgpt service prompt for improved transaction extracion and categorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
This pull request refines and improves the extraction and categorization of credit card transactions from bank statements processed by the `ChatGptService`. The changes focus on making the prompts and instructions for the AI more precise, comprehensive, and tailored to Brazilian banking context, which should result in more accurate and consistent JSON outputs. Additionally, the code is cleaned up to remove outdated comments and improve readability.

**Prompt and instruction enhancements:**

* The system prompt for the AI has been rewritten to provide clearer, stricter rules and more detailed category definitions, including handling of special cases like parcelamentos, estornos, and international purchases. This aims to ensure the AI returns only valid JSON and categorizes transactions more accurately.
* The user prompt generated by `createPrompt` has been expanded with step-by-step extraction instructions, detailed categorization guidelines with real-world examples, and explicit formatting requirements for the output JSON.

**Code cleanup and validation:**

* Removed commented-out mock code for the OpenAI client, streamlining the initialization logic.
* Cleaned up the parsing logic by removing redundant comments, making the JSON parsing and validation steps more straightforward.
* Simplified validation code by removing unnecessary comments, focusing only on essential checks for transaction fields.